### PR TITLE
로그아웃 이슈 : 쿠키 초기화로 로그아웃이 아닌 실제 로그아웃 진행 하도록

### DIFF
--- a/src/hooks/useToken.ts
+++ b/src/hooks/useToken.ts
@@ -22,7 +22,6 @@ const useToken = () => {
         document.cookie = 'zzgg_at=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
         document.cookie = 'zzgg_rt=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
         queryClient.clear();
-        // router.push('/');
     };
     
     const getTokenValue = (tokenName: string) => {

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -22,8 +22,8 @@ interface UserInfo {
 
 const MyPage = () => {
     useAuth();
-    const { logoutDeleteToken } = useToken();
-    const router = useRouter();
+    const { getTokenValue } = useToken();
+    const refreshToken = getTokenValue('zzgg_rt');
     const [showLogoutModal, setShowLogoutModal] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const [userInfo, setUserInfo] = useState<UserInfo>({
@@ -51,10 +51,7 @@ const MyPage = () => {
     
     const onLogout = async () => {
         localStorage.clear();
-        logoutDeleteToken();
-        // todo : 토큰이 안보내지고 있는거 같습니다 401 OR 403.
-        await logout();
-        router.push("/")
+        await logout(refreshToken);
     };
     
     const handleLogoutSectionClick = () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -49,12 +49,16 @@ export const verifyEmailCode = async (email:string, code:string) => {
 
 
 
-export const logout = async () => {
+export const logout = async (refreshToken:string) => {
     try {
-        const response = await axiosInstance.patch('/api/members/logout');
+        const response = await axiosInstance.patch(`/api/members/logout`, {}, {
+            headers: {
+                'RefreshToken': `Bearer ${refreshToken}`
+            }
+        });
         return { success: true, data: response.data };
     } catch (error) {
-        return { success: false, message: '로그아웃 실패' };
+        return { success: false, message: '로그아웃이 정상적으로 되지 않았습니다. 다시 시도해주세요.' };
     }
 };
 


### PR DESCRIPTION
현재 로그아웃을 클릭을 하게 되면 401 에러가 생기는 조건부에 대해 로그아웃에 대한 예외 처리가 없어서 logout -> refresh 순으로 반복 진행하게 됩니다.

이부분을 예외 처리를 진행을 하였습니다. 따라서 401 반복 이슈는 해결 되었습니다.

다만, 
403 에러의 경우에는 
https://velog.io/@woosim34/401-Unauthorized-VS-403Forbidden-HTTP-%EC%83%81%ED%83%9C-%EB%B9%84%EA%B5%90

이렇다고 하는데 방향이 뭔가가 문제가 있던건지 아니면 제가 axios instance 사용 하는 방법에 일부 잘못된 생각을 가지고 있는건지 모르겠습니다. 

우선 남겨봅니당... ㅠㅠ 
내일 오전에 재도전 해볼게요 :) ㅎㅎ
